### PR TITLE
Fix question ID on flow responses API

### DIFF
--- a/flows/test_views.py
+++ b/flows/test_views.py
@@ -686,7 +686,7 @@ class FlowResultViewSetTests(APITestCase):
                     "id": str(self.flow.id),
                     "attributes": {
                         "responses": [
-                            ["2021-02-03T04:05:06.000007Z", i, 1, 1, 1, "a", {}]
+                            ["2021-02-03T04:05:06.000007Z", i, 1, 1, "1", "a", {}]
                             for i in range(5)
                         ]
                     },

--- a/flows/views.py
+++ b/flows/views.py
@@ -368,7 +368,7 @@ class FlowResponseViewSet(viewsets.ViewSet):
             "row_id_type",
             "contact_id_value",
             "session_id_value",
-            "question_id",
+            "question__id",
             "response_value",
             "response_metadata",
         )


### PR DESCRIPTION
The flow responses API was returning the database primary key for the question ID, instead of the question ID.