### PR TITLE
Fix flowresponse migration

### DIFF
--- a/flows/migrations/0005_auto_20210414_0935.py
+++ b/flows/migrations/0005_auto_20210414_0935.py
@@ -32,7 +32,7 @@ class Migration(migrations.Migration):
             preserve_default=False,
         ),
         migrations.RunPython(set_flow, reverse_noop),
-        migrations.AddField(
+        migrations.AlterField(
             model_name="flowresponse",
             name="flow",
             field=models.ForeignKey(


### PR DESCRIPTION
We cannot run AddField twice, it should be AlterField